### PR TITLE
Disambiguate variable named "netmask" when meaning CIDR prefix bits

### DIFF
--- a/include/ipset/ipset.h
+++ b/include/ipset/ipset.h
@@ -134,13 +134,13 @@ ipset_ipv4_add(struct ip_set *set, struct cork_ipv4 *elem);
 
 /**
  * Adds a network of IPv4 addresses to an IP set.  All of the addresses
- * that start with the first netmask bits of elem will be added to the
- * set.  Returns whether the network was already in the set or not.
+ * that start with the first cidr_prefix bits of elem will be added to
+ * the set.  Returns whether the network was already in the set or not.
  */
 
 bool
 ipset_ipv4_add_network(struct ip_set *set, struct cork_ipv4 *elem,
-                       unsigned int netmask);
+                       unsigned int cidr_prefix);
 
 /**
  * Returns whether the given IPv4 address is in an IP set.
@@ -158,13 +158,13 @@ ipset_ipv6_add(struct ip_set *set, struct cork_ipv6 *elem);
 
 /**
  * Adds a network of IPv6 addresses to an IP set.  All of the addresses
- * that start with the first netmask bits of elem will be added to the
- * set.  Returns whether the network was already in the set or not.
+ * that start with the first cidr_prefix bits of elem will be added to
+ * the set.  Returns whether the network was already in the set or not.
  */
 
 bool
 ipset_ipv6_add_network(struct ip_set *set, struct cork_ipv6 *elem,
-                       unsigned int netmask);
+                       unsigned int cidr_prefix);
 
 /**
  * Returns whether the given IPv6 address is in an IP set.
@@ -182,14 +182,14 @@ ipset_ip_add(struct ip_set *set, struct cork_ip *addr);
 
 /**
  * Adds a network of generic IP addresses to an IP set.  All of the
- * addresses that start with the first netmask bits of elem will be
+ * addresses that start with the first cidr_prefix bits of elem will be
  * added to the set.  Returns whether the network was already in the set
  * or not.
  */
 
 bool
 ipset_ip_add_network(struct ip_set *set, struct cork_ip *addr,
-                     unsigned int netmask);
+                     unsigned int cidr_prefix);
 
 /**
  * Returns whether the given generic IP address is in an IP set.
@@ -249,9 +249,9 @@ struct ipset_iterator {
     /* The address of the current IP network in the iterator. */
     struct cork_ip  addr;
 
-    /* The netmask of the current IP network in the iterator.  For a
-     * single IP address, this will be 32 or 128. */
-    unsigned int  netmask;
+    /* The netmask of the current IP network in the iterator, given as a
+     * CIDR prefix.  For a single IP address, this will be 32 or 128. */
+    unsigned int  cidr_prefix;
 };
 
 
@@ -376,11 +376,12 @@ ipmap_ipv4_set(struct ip_map *map, struct cork_ipv4 *elem, int value);
 /**
  * Adds a network of IPv4 addresses to an IP map, with each address in
  * the network mapping to the given value.  All of the addresses that
- * start with the first netmask bits of elem will be added to the map.
+ * start with the first cidr_prefix bits of elem will be added to the
+ * map.
  */
 void
 ipmap_ipv4_set_network(struct ip_map *map, struct cork_ipv4 *elem,
-                       unsigned int netmask, int value);
+                       unsigned int cidr_prefix, int value);
 
 /**
  * Returns the value that an IPv4 address is mapped to in the map.
@@ -397,11 +398,12 @@ ipmap_ipv6_set(struct ip_map *map, struct cork_ipv6 *elem, int value);
 /**
  * Adds a network of IPv6 addresses to an IP map, with each address in
  * the network mapping to the given value.  All of the addresses that
- * start with the first netmask bits of elem will be added to the map.
+ * start with the first cidr_prefix bits of elem will be added to the
+ * map.
  */
 void
 ipmap_ipv6_set_network(struct ip_map *map, struct cork_ipv6 *elem,
-                       unsigned int netmask, int value);
+                       unsigned int cidr_prefix, int value);
 
 /**
  * Returns the value that an IPv6 address is mapped to in the map.
@@ -418,12 +420,12 @@ ipmap_ip_set(struct ip_map *map, struct cork_ip *addr, int value);
 /**
  * Adds a network of generic IP addresses to an IP map, with each
  * address in the network mapping to the given value.  All of the
- * addresses that start with the first netmask bits of elem will be
+ * addresses that start with the first cidr_prefix bits of elem will be
  * added to the map.
  */
 void
 ipmap_ip_set_network(struct ip_map *map, struct cork_ip *addr,
-                     unsigned int netmask, int value);
+                     unsigned int cidr_prefix, int value);
 
 /**
  * Returns the value that a generic IP address is mapped to in the

--- a/src/ipsetcat/ipsetcat.c
+++ b/src/ipsetcat/ipsetcat.c
@@ -143,7 +143,7 @@ main(int argc, char **argv)
              !it->finished;
              ipset_iterator_advance(it)) {
             cork_ip_to_raw_string(&it->addr, ip_buf);
-            cork_buffer_printf(&buf, "%s/%u\n", ip_buf, it->netmask);
+            cork_buffer_printf(&buf, "%s/%u\n", ip_buf, it->cidr_prefix);
 
             if (fputs(buf.buf, ostream) == EOF) {
                 fprintf(stderr, "Cannot write to file %s:\n  %s\n",

--- a/src/libipset/internal.h
+++ b/src/libipset/internal.h
@@ -22,18 +22,19 @@ extern struct ipset_node_cache  *ipset_cache;
 /**
  * Create a BDD for an IP address or family of IP addresses.  The
  * corresponding BDD will have each boolean variable set if the
- * corresponding bit is set in the IP address.  The netmask parameter
- * can be used to limit the number of bits to constrain; if this is less
- * than IPVX_BIT_SIZE, then an entire network will be added to the set.
- * The values of the BDD will all be 0 or 1, so the BDD is acceptable to
- * pass in as the condition in a call to ipset_node_cache_ite().
+ * corresponding bit is set in the IP address.  The cidr_prefix
+ * parameter can be used to limit the number of bits to constrain; if
+ * this is less than IPVX_BIT_SIZE, then an entire network will be added
+ * to the set.  The values of the BDD will all be 0 or 1, so the BDD is
+ * acceptable to pass in as the condition in a call to
+ * ipset_node_cache_ite().
  */
 
 ipset_node_id
-ipset_ipv4_make_ip_bdd(struct cork_ipv4 *addr, unsigned int netmask);
+ipset_ipv4_make_ip_bdd(struct cork_ipv4 *addr, unsigned int cidr_prefix);
 
 ipset_node_id
-ipset_ipv6_make_ip_bdd(struct cork_ipv6 *addr, unsigned int netmask);
+ipset_ipv6_make_ip_bdd(struct cork_ipv6 *addr, unsigned int cidr_prefix);
 
 
 #endif  /* IPSET_INTERNAL_H */

--- a/src/libipset/map/inspection.c
+++ b/src/libipset/map/inspection.c
@@ -49,12 +49,12 @@ ipmap_ip_set(struct ip_map *map, struct cork_ip *addr, int value)
 
 void
 ipmap_ip_set_network(struct ip_map *map, struct cork_ip *addr,
-                     unsigned int netmask, int value)
+                     unsigned int cidr_prefix, int value)
 {
     if (addr->version == 4) {
-        ipmap_ipv4_set_network(map, &addr->ip.v4, netmask, value);
+        ipmap_ipv4_set_network(map, &addr->ip.v4, cidr_prefix, value);
     } else {
-        ipmap_ipv6_set_network(map, &addr->ip.v6, netmask, value);
+        ipmap_ipv6_set_network(map, &addr->ip.v6, cidr_prefix, value);
     }
 }
 

--- a/src/libipset/map/modify-template.c.in
+++ b/src/libipset/map/modify-template.c.in
@@ -17,7 +17,7 @@
 
 void
 IPMAP_NAME(set_network)(struct ip_map *map, CORK_IP *elem,
-                        unsigned int netmask, int value)
+                        unsigned int cidr_prefix, int value)
 {
     ipset_node_id  elem_bdd;
     ipset_node_id  value_bdd;
@@ -26,7 +26,7 @@ IPMAP_NAME(set_network)(struct ip_map *map, CORK_IP *elem,
     /* First, construct the BDD that represents this IP address — i.e.,
      * where each boolean variable is assigned TRUE or FALSE depending
      * on whether the corresponding bit is set in the address. */
-    elem_bdd = IPSET_NAME(make_ip_bdd)(elem, netmask);
+    elem_bdd = IPSET_NAME(make_ip_bdd)(elem, cidr_prefix);
 
     /* Next, create a new constant BDD to represent the value. */
     value_bdd = ipset_node_cache_terminal(ipset_cache, value);

--- a/src/libipset/set/inspection.c
+++ b/src/libipset/set/inspection.c
@@ -50,12 +50,12 @@ ipset_ip_add(struct ip_set *set, struct cork_ip *addr)
 
 bool
 ipset_ip_add_network(struct ip_set *set, struct cork_ip *addr,
-                     unsigned int netmask)
+                     unsigned int cidr_prefix)
 {
     if (addr->version == 4) {
-        return ipset_ipv4_add_network(set, &addr->ip.v4, netmask);
+        return ipset_ipv4_add_network(set, &addr->ip.v4, cidr_prefix);
     } else {
-        return ipset_ipv6_add_network(set, &addr->ip.v6, netmask);
+        return ipset_ipv6_add_network(set, &addr->ip.v6, cidr_prefix);
     }
 }
 

--- a/src/libipset/set/internal-template.c.in
+++ b/src/libipset/set/internal-template.c.in
@@ -31,12 +31,12 @@ IPSET_NAME(var_for_bit)(unsigned int bit)
 
 
 ipset_node_id
-IPSET_NAME(make_ip_bdd)(CORK_IP *addr, unsigned int netmask)
+IPSET_NAME(make_ip_bdd)(CORK_IP *addr, unsigned int cidr_prefix)
 {
     /* Special case — the BDD for a netmask that's out of range never
      * evaluates to true. */
 
-    if ((netmask == 0) || (netmask > IP_BIT_SIZE)) {
+    if ((cidr_prefix == 0) || (cidr_prefix > IP_BIT_SIZE)) {
         return ipset_node_cache_terminal(ipset_cache, false);
     }
 
@@ -50,7 +50,7 @@ IPSET_NAME(make_ip_bdd)(CORK_IP *addr, unsigned int netmask)
     /* Since the BDD needs to be ordered, we have to iterate through the
      * IP address's bits in reverse order. */
     int  i;
-    for (i = netmask-1; i >= 0; i--) {
+    for (i = cidr_prefix-1; i >= 0; i--) {
         ipset_variable  var = IPSET_NAME(var_for_bit)(i);
 
         if (IPSET_BIT_GET(addr, i)) {

--- a/src/libipset/set/iterator.c
+++ b/src/libipset/set/iterator.c
@@ -71,14 +71,14 @@ create_ip_address(struct ipset_iterator *iterator)
      * copy is given as the current netmask.  We'll have calculated that
      * already based on the non-expanded assignment. */
     unsigned int  i;
-    for (i = 0; i < iterator->netmask; i++) {
+    for (i = 0; i < iterator->cidr_prefix; i++) {
         IPSET_BIT_SET(&addr->ip, i, IPSET_BIT_GET(exp->values.buf, i+1));
     }
 
 #if IPSET_DEBUG
     char  buf[CORK_IP_STRING_LENGTH];
     cork_ip_to_raw_string(addr, buf);
-    DEBUG("Current IP address is %s/%u", buf, iterator->netmask);
+    DEBUG("Current IP address is %s/%u", buf, iterator->cidr_prefix);
 #endif
 }
 
@@ -177,7 +177,7 @@ expand_ipv4(struct ipset_iterator *iterator)
     iterator->assignment_iterator =
         ipset_assignment_expand
         (iterator->bdd_iterator->assignment, last_bit + 1);
-    iterator->netmask = last_bit;
+    iterator->cidr_prefix = last_bit;
 
     process_expanded_assignment(iterator);
 }
@@ -202,7 +202,7 @@ expand_ipv6(struct ipset_iterator *iterator)
     iterator->assignment_iterator =
         ipset_assignment_expand
         (iterator->bdd_iterator->assignment, last_bit + 1);
-    iterator->netmask = last_bit;
+    iterator->cidr_prefix = last_bit;
 
     process_expanded_assignment(iterator);
 }

--- a/src/libipset/set/modify-template.c.in
+++ b/src/libipset/set/modify-template.c.in
@@ -16,7 +16,8 @@
 
 
 bool
-IPSET_NAME(add_network)(struct ip_set *set, CORK_IP *elem, unsigned int netmask)
+IPSET_NAME(add_network)(struct ip_set *set, CORK_IP *elem,
+                        unsigned int cidr_prefix)
 {
     ipset_node_id  elem_bdd;
     ipset_node_id  new_set_bdd;
@@ -25,7 +26,7 @@ IPSET_NAME(add_network)(struct ip_set *set, CORK_IP *elem, unsigned int netmask)
     /* First, construct the BDD that represents this IP address — i.e.,
      * where each boolean variable is assigned TRUE or FALSE depending
      * on whether the corresponding bit is set in the address. */
-    elem_bdd = IPSET_NAME(make_ip_bdd)(elem, netmask);
+    elem_bdd = IPSET_NAME(make_ip_bdd)(elem, cidr_prefix);
 
     /* Add elem to the set by constructing the logical OR of the old set
      * and the new element's BDD. */

--- a/tests/test-ipmap.c
+++ b/tests/test-ipmap.c
@@ -242,7 +242,7 @@ START_TEST(test_ipv4_insert_network_03)
 }
 END_TEST
 
-START_TEST(test_ipv4_bad_netmask_01)
+START_TEST(test_ipv4_bad_cidr_prefix_01)
 {
     struct ip_map  map;
     struct cork_ipv4  addr;
@@ -251,12 +251,12 @@ START_TEST(test_ipv4_bad_netmask_01)
     cork_ipv4_init(&addr, "192.168.1.100");
     ipmap_ipv4_set_network(&map, &addr, 0, 1);
     fail_unless(ipmap_is_empty(&map),
-                "Bad netmask shouldn't change map");
+                "Bad CIDR prefix shouldn't change map");
     ipmap_done(&map);
 }
 END_TEST
 
-START_TEST(test_ipv4_bad_netmask_02)
+START_TEST(test_ipv4_bad_cidr_prefix_02)
 {
     struct ip_map  map;
     struct cork_ipv4  addr;
@@ -265,7 +265,7 @@ START_TEST(test_ipv4_bad_netmask_02)
     cork_ipv4_init(&addr, "192.168.1.100");
     ipmap_ipv4_set_network(&map, &addr, 33, 1);
     fail_unless(ipmap_is_empty(&map),
-                "Bad netmask shouldn't change map");
+                "Bad CIDR prefix shouldn't change map");
     ipmap_done(&map);
 }
 END_TEST
@@ -495,7 +495,7 @@ START_TEST(test_ipv6_insert_network_03)
 }
 END_TEST
 
-START_TEST(test_ipv6_bad_netmask_01)
+START_TEST(test_ipv6_bad_cidr_prefix_01)
 {
     struct ip_map  map;
     struct cork_ipv6  addr;
@@ -504,12 +504,12 @@ START_TEST(test_ipv6_bad_netmask_01)
     cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
     ipmap_ipv6_set_network(&map, &addr, 0, 1);
     fail_unless(ipmap_is_empty(&map),
-                "Bad netmask shouldn't change map");
+                "Bad CIDR prefix shouldn't change map");
     ipmap_done(&map);
 }
 END_TEST
 
-START_TEST(test_ipv6_bad_netmask_02)
+START_TEST(test_ipv6_bad_cidr_prefix_02)
 {
     struct ip_map  map;
     struct cork_ipv6  addr;
@@ -518,7 +518,7 @@ START_TEST(test_ipv6_bad_netmask_02)
     cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
     ipmap_ipv6_set_network(&map, &addr, 129, 1);
     fail_unless(ipmap_is_empty(&map),
-                "Bad netmask shouldn't change map");
+                "Bad CIDR prefix shouldn't change map");
     ipmap_done(&map);
 }
 END_TEST
@@ -679,8 +679,8 @@ ipmap_suite()
     tcase_add_test(tc_ipv4, test_ipv4_insert_network_01);
     tcase_add_test(tc_ipv4, test_ipv4_insert_network_02);
     tcase_add_test(tc_ipv4, test_ipv4_insert_network_03);
-    tcase_add_test(tc_ipv4, test_ipv4_bad_netmask_01);
-    tcase_add_test(tc_ipv4, test_ipv4_bad_netmask_02);
+    tcase_add_test(tc_ipv4, test_ipv4_bad_cidr_prefix_01);
+    tcase_add_test(tc_ipv4, test_ipv4_bad_cidr_prefix_02);
     tcase_add_test(tc_ipv4, test_ipv4_equality_1);
     tcase_add_test(tc_ipv4, test_ipv4_inequality_1);
     tcase_add_test(tc_ipv4, test_ipv4_inequality_2);
@@ -696,8 +696,8 @@ ipmap_suite()
     tcase_add_test(tc_ipv6, test_ipv6_insert_network_01);
     tcase_add_test(tc_ipv6, test_ipv6_insert_network_02);
     tcase_add_test(tc_ipv6, test_ipv6_insert_network_03);
-    tcase_add_test(tc_ipv6, test_ipv6_bad_netmask_01);
-    tcase_add_test(tc_ipv6, test_ipv6_bad_netmask_02);
+    tcase_add_test(tc_ipv6, test_ipv6_bad_cidr_prefix_01);
+    tcase_add_test(tc_ipv6, test_ipv6_bad_cidr_prefix_02);
     tcase_add_test(tc_ipv6, test_ipv6_equality_1);
     tcase_add_test(tc_ipv6, test_ipv6_inequality_1);
     tcase_add_test(tc_ipv6, test_ipv6_inequality_2);

--- a/tests/test-ipset.c
+++ b/tests/test-ipset.c
@@ -160,7 +160,7 @@ START_TEST(test_ipv4_insert_network_01)
 }
 END_TEST
 
-START_TEST(test_ipv4_bad_netmask_01)
+START_TEST(test_ipv4_bad_cidr_prefix_01)
 {
     struct ip_set  set;
     struct cork_ipv4  addr;
@@ -169,12 +169,12 @@ START_TEST(test_ipv4_bad_netmask_01)
     cork_ipv4_init(&addr, "192.168.1.100");
     ipset_ipv4_add_network(&set, &addr, 0);
     fail_unless(ipset_is_empty(&set),
-                "Bad netmask shouldn't change set");
+                "Bad CIDR prefix shouldn't change set");
     ipset_done(&set);
 }
 END_TEST
 
-START_TEST(test_ipv4_bad_netmask_02)
+START_TEST(test_ipv4_bad_cidr_prefix_02)
 {
     struct ip_set  set;
     struct cork_ipv4  addr;
@@ -183,7 +183,7 @@ START_TEST(test_ipv4_bad_netmask_02)
     cork_ipv4_init(&addr, "192.168.1.100");
     ipset_ipv4_add_network(&set, &addr, 33);
     fail_unless(ipset_is_empty(&set),
-                "Bad netmask shouldn't change set");
+                "Bad CIDR prefix shouldn't change set");
     ipset_done(&set);
 }
 END_TEST
@@ -409,7 +409,7 @@ START_TEST(test_ipv6_insert_network_01)
 }
 END_TEST
 
-START_TEST(test_ipv6_bad_netmask_01)
+START_TEST(test_ipv6_bad_cidr_prefix_01)
 {
     struct ip_set  set;
     struct cork_ipv6  addr;
@@ -418,12 +418,12 @@ START_TEST(test_ipv6_bad_netmask_01)
     cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
     ipset_ipv6_add_network(&set, &addr, 0);
     fail_unless(ipset_is_empty(&set),
-                "Bad netmask shouldn't change set");
+                "Bad CIDR prefix shouldn't change set");
     ipset_done(&set);
 }
 END_TEST
 
-START_TEST(test_ipv6_bad_netmask_02)
+START_TEST(test_ipv6_bad_cidr_prefix_02)
 {
     struct ip_set  set;
     struct cork_ipv6  addr;
@@ -432,7 +432,7 @@ START_TEST(test_ipv6_bad_netmask_02)
     cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
     ipset_ipv6_add_network(&set, &addr, 129);
     fail_unless(ipset_is_empty(&set),
-                "Bad netmask shouldn't change set");
+                "Bad CIDR prefix shouldn't change set");
     ipset_done(&set);
 }
 END_TEST
@@ -640,8 +640,8 @@ ipset_suite()
     TCase  *tc_ipv4 = tcase_create("ipv4");
     tcase_add_test(tc_ipv4, test_ipv4_insert_01);
     tcase_add_test(tc_ipv4, test_ipv4_insert_network_01);
-    tcase_add_test(tc_ipv4, test_ipv4_bad_netmask_01);
-    tcase_add_test(tc_ipv4, test_ipv4_bad_netmask_02);
+    tcase_add_test(tc_ipv4, test_ipv4_bad_cidr_prefix_01);
+    tcase_add_test(tc_ipv4, test_ipv4_bad_cidr_prefix_02);
     tcase_add_test(tc_ipv4, test_ipv4_contains_01);
     tcase_add_test(tc_ipv4, test_ipv4_contains_02);
     tcase_add_test(tc_ipv4, test_ipv4_network_contains_01);
@@ -657,8 +657,8 @@ ipset_suite()
     TCase  *tc_ipv6 = tcase_create("ipv6");
     tcase_add_test(tc_ipv6, test_ipv6_insert_01);
     tcase_add_test(tc_ipv6, test_ipv6_insert_network_01);
-    tcase_add_test(tc_ipv6, test_ipv6_bad_netmask_01);
-    tcase_add_test(tc_ipv6, test_ipv6_bad_netmask_02);
+    tcase_add_test(tc_ipv6, test_ipv6_bad_cidr_prefix_01);
+    tcase_add_test(tc_ipv6, test_ipv6_bad_cidr_prefix_02);
     tcase_add_test(tc_ipv6, test_ipv6_contains_01);
     tcase_add_test(tc_ipv6, test_ipv6_contains_02);
     tcase_add_test(tc_ipv6, test_ipv6_network_contains_01);

--- a/tests/test-iterator.c
+++ b/tests/test-iterator.c
@@ -58,8 +58,8 @@ START_TEST(test_ipv4_iterate_01)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == IPV4_BIT_SIZE,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == IPV4_BIT_SIZE,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -91,8 +91,8 @@ START_TEST(test_ipv4_iterate_network_01)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 31,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == 31,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -124,8 +124,8 @@ START_TEST(test_ipv4_iterate_network_02)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 16,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == 16,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -168,8 +168,8 @@ START_TEST(test_ipv4_iterate_network_03)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 31,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == 31,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -201,8 +201,8 @@ START_TEST(test_ipv6_iterate_01)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == IPV6_BIT_SIZE,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == IPV6_BIT_SIZE,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -234,8 +234,8 @@ START_TEST(test_ipv6_iterate_network_01)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 127,
-                "IP netmask 0 doesn't match (%u)", it->netmask);
+    fail_unless(it->cidr_prefix == 127,
+                "IP CIDR prefix 0 doesn't match (%u)", it->cidr_prefix);
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -267,8 +267,8 @@ START_TEST(test_ipv6_iterate_network_02)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 16,
-                "IP netmask 0 doesn't match (%u)", it->netmask);
+    fail_unless(it->cidr_prefix == 16,
+                "IP CIDR prefix 0 doesn't match (%u)", it->cidr_prefix);
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -311,8 +311,8 @@ START_TEST(test_ipv6_iterate_network_03)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 127,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == 127,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -344,16 +344,16 @@ START_TEST(test_generic_ip_iterate_01)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 0,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == 0,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_if(it->finished,
             "IP set should have more than 1 element");
     fail_unless(cork_ip_equal(&ip2, &it->addr),
                 "IP address 1 doesn't match");
-    fail_unless(it->netmask == 0,
-                "IP netmask 1 doesn't match");
+    fail_unless(it->cidr_prefix == 0,
+                "IP CIDR prefix 1 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,
@@ -398,16 +398,16 @@ START_TEST(test_generic_ip_iterate_02)
             "IP set shouldn't be empty");
     fail_unless(cork_ip_equal(&ip1, &it->addr),
                 "IP address 0 doesn't match");
-    fail_unless(it->netmask == 32,
-                "IP netmask 0 doesn't match");
+    fail_unless(it->cidr_prefix == 32,
+                "IP CIDR prefix 0 doesn't match");
 
     ipset_iterator_advance(it);
     fail_if(it->finished,
             "IP set should have more than 1 element");
     fail_unless(cork_ip_equal(&ip2, &it->addr),
                 "IP address 1 doesn't match");
-    fail_unless(it->netmask == 32,
-                "IP netmask 1 doesn't match");
+    fail_unless(it->cidr_prefix == 32,
+                "IP CIDR prefix 1 doesn't match");
 
     ipset_iterator_advance(it);
     fail_unless(it->finished,


### PR DESCRIPTION
The use of the variable name netmask for a variable that actually specifies the number of bits in the cidr prefix is confusing. While adding the cidr support, I initially converted /24 to its mask form 255.255.255.0 and used it as the argument. It did not work, but did not error, either.
