### PR TITLE
libipset needs a lookup function

### DIFF
--- a/include/ipset/ipset.h
+++ b/include/ipset/ipset.h
@@ -143,6 +143,12 @@ ipset_ipv4_add_network(struct ip_set *set, struct cork_ipv4 *elem,
                        unsigned int netmask);
 
 /**
+ * Returns whether the given IPv4 address is in an IP set.
+ */
+bool
+ipset_contains_ipv4(const struct ip_set *set, struct cork_ipv4 *elem);
+
+/**
  * Adds a single IPv6 address to an IP set.  Returns whether the value
  * was already in the set or not.
  */
@@ -159,6 +165,12 @@ ipset_ipv6_add(struct ip_set *set, struct cork_ipv6 *elem);
 bool
 ipset_ipv6_add_network(struct ip_set *set, struct cork_ipv6 *elem,
                        unsigned int netmask);
+
+/**
+ * Returns whether the given IPv6 address is in an IP set.
+ */
+bool
+ipset_contains_ipv6(const struct ip_set *set, struct cork_ipv6 *elem);
 
 /**
  * Adds a single generic IP address to an IP set.  Returns whether the
@@ -178,6 +190,12 @@ ipset_ip_add(struct ip_set *set, struct cork_ip *addr);
 bool
 ipset_ip_add_network(struct ip_set *set, struct cork_ip *addr,
                      unsigned int netmask);
+
+/**
+ * Returns whether the given generic IP address is in an IP set.
+ */
+bool
+ipset_contains_ip(const struct ip_set *set, struct cork_ip *elem);
 
 
 /**

--- a/src/libipset/set/inspection-template.c.in
+++ b/src/libipset/set/inspection-template.c.in
@@ -1,0 +1,53 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2012, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the LICENSE.txt file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+#include <libcork/core.h>
+
+#include "ipset/bdd/nodes.h"
+#include "ipset/ipset.h"
+#include "../internal.h"
+
+
+/**
+ * Given a BDD variable number, return the index of the corresponding
+ * bit in an IP address.  IPv4 addresses use variables 1-32; IPv6
+ * addresses use 1-128.  (Variable 0 is used to identify the kind of
+ * address — TRUE for IPv4, FALSE for IPv6.)
+ */
+
+static unsigned int
+IPSET_NAME(bit_for_var)(ipset_variable var)
+{
+    return (var - 1);
+}
+
+
+/**
+ * An assignment function that can be used to evaluate an IP set BDD.
+ */
+
+static bool
+IPSET_NAME(assignment)(const void *addr, ipset_variable var)
+{
+    if (var == 0) {
+        return IP_DISCRIMINATOR_VALUE;
+    } else {
+        unsigned int  bit = IPSET_NAME(bit_for_var)(var);
+        return IPSET_BIT_GET(addr, bit);
+    }
+}
+
+
+bool
+IPSET_PRENAME(contains)(const struct ip_set *set, CORK_IP *elem)
+{
+    return ipset_node_evaluate
+        (set->set_bdd, IPSET_NAME(assignment), elem);
+}

--- a/src/libipset/set/inspection.c
+++ b/src/libipset/set/inspection.c
@@ -59,3 +59,13 @@ ipset_ip_add_network(struct ip_set *set, struct cork_ip *addr,
     }
 }
 
+
+bool
+ipset_contains_ip(const struct ip_set *set, struct cork_ip *addr)
+{
+    if (addr->version == 4) {
+        return ipset_contains_ipv4(set, &addr->ip.v4);
+    } else {
+        return ipset_contains_ipv6(set, &addr->ip.v6);
+    }
+}

--- a/src/libipset/set/ipv4_set.c
+++ b/src/libipset/set/ipv4_set.c
@@ -29,7 +29,11 @@
 /* Creates a identifier of the form “ipset_ipv4_<basename>”. */
 #define IPSET_NAME(basename) ipset_ipv4_##basename
 
+/* Creates a identifier of the form “ipset_<basename>_ipv4”. */
+#define IPSET_PRENAME(basename) ipset_##basename##_ipv4
+
 
 /* Now include all of the templates. */
+#include "inspection-template.c.in"
 #include "internal-template.c.in"
 #include "modify-template.c.in"

--- a/src/libipset/set/ipv6_set.c
+++ b/src/libipset/set/ipv6_set.c
@@ -30,7 +30,11 @@
 /* Creates a identifier of the form “ipset_ipv6_<basename>”. */
 #define IPSET_NAME(basename) ipset_ipv6_##basename
 
+/* Creates a identifier of the form “ipset_<basename>_ipv6”. */
+#define IPSET_PRENAME(basename) ipset_##basename##_ipv6
+
 
 /* Now include all of the templates. */
+#include "inspection-template.c.in"
 #include "internal-template.c.in"
 #include "modify-template.c.in"

--- a/tests/test-ipset.c
+++ b/tests/test-ipset.c
@@ -188,6 +188,53 @@ START_TEST(test_ipv4_bad_netmask_02)
 }
 END_TEST
 
+START_TEST(test_ipv4_contains_01)
+{
+    struct ip_set  set;
+    struct cork_ipv4  addr;
+
+    ipset_init(&set);
+    cork_ipv4_init(&addr, "192.168.1.100");
+    fail_if(ipset_ipv4_add(&set, &addr),
+            "Element should not be present");
+    fail_unless(ipset_contains_ipv4(&set, &addr),
+                "Element should be present");
+    ipset_done(&set);
+}
+END_TEST
+
+START_TEST(test_ipv4_contains_02)
+{
+    struct ip_set  set;
+    struct cork_ipv4  addr;
+    struct cork_ip  ip;
+
+    ipset_init(&set);
+    cork_ipv4_init(&addr, "192.168.1.100");
+    cork_ip_from_ipv4(&ip, &addr);
+    fail_if(ipset_ipv4_add(&set, &addr),
+            "Element should not be present");
+    fail_unless(ipset_contains_ip(&set, &ip),
+                "Element should be present");
+    ipset_done(&set);
+}
+END_TEST
+
+START_TEST(test_ipv4_network_contains_01)
+{
+    struct ip_set  set;
+    struct cork_ipv4  addr;
+
+    ipset_init(&set);
+    cork_ipv4_init(&addr, "192.168.1.100");
+    fail_if(ipset_ipv4_add_network(&set, &addr, 24),
+            "Element should not be present");
+    fail_unless(ipset_contains_ipv4(&set, &addr),
+                "Element should be present");
+    ipset_done(&set);
+}
+END_TEST
+
 START_TEST(test_ipv4_equality_1)
 {
     struct ip_set  set1, set2;
@@ -390,6 +437,53 @@ START_TEST(test_ipv6_bad_netmask_02)
 }
 END_TEST
 
+START_TEST(test_ipv6_contains_01)
+{
+    struct ip_set  set;
+    struct cork_ipv6  addr;
+
+    ipset_init(&set);
+    cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
+    fail_if(ipset_ipv6_add(&set, &addr),
+            "Element should not be present");
+    fail_unless(ipset_contains_ipv6(&set, &addr),
+                "Element should be present");
+    ipset_done(&set);
+}
+END_TEST
+
+START_TEST(test_ipv6_contains_02)
+{
+    struct ip_set  set;
+    struct cork_ipv6  addr;
+    struct cork_ip  ip;
+
+    ipset_init(&set);
+    cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
+    cork_ip_from_ipv6(&ip, &addr);
+    fail_if(ipset_ipv6_add(&set, &addr),
+            "Element should not be present");
+    fail_unless(ipset_contains_ip(&set, &ip),
+                "Element should be present");
+    ipset_done(&set);
+}
+END_TEST
+
+START_TEST(test_ipv6_network_contains_01)
+{
+    struct ip_set  set;
+    struct cork_ipv6  addr;
+
+    ipset_init(&set);
+    cork_ipv6_init(&addr, "fe80::21e:c2ff:fe9f:e8e1");
+    fail_if(ipset_ipv6_add_network(&set, &addr, 32),
+            "Element should not be present");
+    fail_unless(ipset_contains_ipv6(&set, &addr),
+                "Element should be present");
+    ipset_done(&set);
+}
+END_TEST
+
 START_TEST(test_ipv6_equality_1)
 {
     struct ip_set  set1, set2;
@@ -548,6 +642,9 @@ ipset_suite()
     tcase_add_test(tc_ipv4, test_ipv4_insert_network_01);
     tcase_add_test(tc_ipv4, test_ipv4_bad_netmask_01);
     tcase_add_test(tc_ipv4, test_ipv4_bad_netmask_02);
+    tcase_add_test(tc_ipv4, test_ipv4_contains_01);
+    tcase_add_test(tc_ipv4, test_ipv4_contains_02);
+    tcase_add_test(tc_ipv4, test_ipv4_network_contains_01);
     tcase_add_test(tc_ipv4, test_ipv4_equality_1);
     tcase_add_test(tc_ipv4, test_ipv4_inequality_1);
     tcase_add_test(tc_ipv4, test_ipv4_memory_size_1);
@@ -562,6 +659,9 @@ ipset_suite()
     tcase_add_test(tc_ipv6, test_ipv6_insert_network_01);
     tcase_add_test(tc_ipv6, test_ipv6_bad_netmask_01);
     tcase_add_test(tc_ipv6, test_ipv6_bad_netmask_02);
+    tcase_add_test(tc_ipv6, test_ipv6_contains_01);
+    tcase_add_test(tc_ipv6, test_ipv6_contains_02);
+    tcase_add_test(tc_ipv6, test_ipv6_network_contains_01);
     tcase_add_test(tc_ipv6, test_ipv6_equality_1);
     tcase_add_test(tc_ipv6, test_ipv6_inequality_1);
     tcase_add_test(tc_ipv6, test_ipv6_memory_size_1);


### PR DESCRIPTION
In order to use the bdd based ipsets in a filter, a function is needed to determine whether or not a given IP is in a given set.

bool ipset_contains_ip(struct ip_set *set, struct cork_ip *addr);

Probably with the variants for ipv4 and ipv6 addresses

bool ipset_contains_ipv4(struct ip_set *set, struct cork_ipv4 *addr);
bool ipset_contains_ipv6(struct ip_set *set, struct cork_ipv6 *addr);
