### PR TITLE
CIDR block range checking in ipsetbuild

### DIFF
--- a/src/ipsetbuild/ipsetbuild.c
+++ b/src/ipsetbuild/ipsetbuild.c
@@ -142,7 +142,8 @@ main(int argc, char **argv)
             } else {
                 ipset_ip_add_network(&set, &addr, cidr); 
                 if (cork_error_occurred()) {
-                    fprintf(stderr, "* Skipping %s/%u: %s\n", line, cidr, cork_error_message());
+                    fprintf(stderr, "* Skipping %s/%u: %s\n", 
+                            line, cidr, cork_error_message());
                     cork_error_clear();
                     continue;
                 }

--- a/src/libipset/set/internal-template.c.in
+++ b/src/libipset/set/internal-template.c.in
@@ -36,7 +36,8 @@ IPSET_NAME(make_ip_bdd)(CORK_IP *addr, unsigned int cidr_prefix)
     /* Special case — the BDD for a netmask that's out of range never
      * evaluates to true. */
     if ((cidr_prefix == 0) || (cidr_prefix > IP_BIT_SIZE)) {
-        cork_error_set(IPSET_ERROR, IPSET_IO_ERROR, "CIDR block %u out of range [0..%u]", cidr_prefix, IP_BIT_SIZE);
+        cork_error_set(IPSET_ERROR, IPSET_PARSE_ERROR, 
+                "CIDR block %u out of range [0..%u]", cidr_prefix, IP_BIT_SIZE);
         return ipset_node_cache_terminal(ipset_cache, false);
     }
 


### PR DESCRIPTION
Updated ipsetbuild to do basic range checking on CIDR blocks ([0..32]
for IPv4 and [0..128] for IPv6) in input files. Input addresses with bad
ranges are skipped and an error message is given.
