### PR TITLE
Improved error checking for IP/CIDR address input

### DIFF
--- a/src/ipsetbuild/ipsetbuild.c
+++ b/src/ipsetbuild/ipsetbuild.c
@@ -168,7 +168,7 @@ main(int argc, char **argv)
                 /* If loose-cidr was not a command line option, then check the
                  * alignment of the IP address with the CIDR block. */
                 if (!loose_cidr) {
-                    if (cork_ip_is_valid_network(&addr, cidr) == false) {
+                    if (!cork_ip_is_valid_network(&addr, cidr)) {
                         fprintf(stderr, "* Skipping %s/%u: Bad CIDR block.\n",
                                 line, cidr);
                         continue;


### PR DESCRIPTION
This version utilizes a new libcork function for checking if IP addresses are aligned with a given CIDR block. It also introduce a new command line option `--loose-cidr` to turn off this check.

The current error checking code is a bit awkward and could be refactored if we update the cork_ip_is_valid_network() to include a parameter for loose or hard CIDR block checks. 
