### PR TITLE
"usage" error in ipsetcat

### DIFF
--- a/src/ipsetcat/ipsetcat.c
+++ b/src/ipsetcat/ipsetcat.c
@@ -69,8 +69,8 @@ main(int argc, char **argv)
     argc -= optind;
     argv += optind;
 
-    if (argc != 1) {
-        fprintf(stderr, "ERROR: You need to specify a single input file.\n");
+    if (argc > 1) {
+        fprintf(stderr, "ERROR: You cannot specify multiple input files.\n");
         usage();
         exit(1);
     }


### PR DESCRIPTION
The usage statement for ipsetcat is

```
Usage: ipsetcat [--input=<input file>]
                [--output=<output file>]
                [--networks]
                <IP file>
```

However the last line <IP file> seems to be in error as the code processes only the file given as part of the --input option.
